### PR TITLE
[chore] 이슈/PR 자동 라벨링 및 담당자 고정

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -1,0 +1,108 @@
+name: Auto Triage
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-and-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign and label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const fixedAssignee = 'maehwasoo';
+            const labelMap = {
+              feat: '💫 Feature',
+              fix: '🔧 Fix',
+              docs: '📄 Docs',
+              refactor: '🛠️ Refactor',
+              style: '🎨 Style',
+              test: '🧪 Test',
+              chore: '⚙️ Setting',
+              deploy: '🌐 Deploy',
+            };
+            const typeLabels = new Set(Object.values(labelMap));
+
+            const isIssue = context.eventName === 'issues';
+            const isPullRequest = context.eventName === 'pull_request_target';
+            if (!isIssue && !isPullRequest) {
+              console.log(`Unsupported event: ${context.eventName}`);
+              process.exit(0);
+            }
+
+            const number = isIssue
+              ? context.payload.issue.number
+              : context.payload.pull_request.number;
+            const title = isIssue
+              ? context.payload.issue.title ?? ''
+              : context.payload.pull_request.title ?? '';
+
+            if (isIssue && context.payload.issue.pull_request) {
+              console.log('Skipping: issues event for a pull request.');
+              process.exit(0);
+            }
+
+            try {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: number,
+                assignees: [fixedAssignee],
+              });
+            } catch (error) {
+              console.log('Failed to add assignee:', error?.message ?? error);
+            }
+
+            const match = title.match(/^\[(feat|fix|docs|refactor|style|test|chore|deploy)\]/i);
+            const type = match?.[1]?.toLowerCase();
+            const targetLabel = type ? labelMap[type] : null;
+
+            if (!targetLabel) {
+              console.log('No recognized type prefix; leaving labels unchanged.');
+              process.exit(0);
+            }
+
+            const currentLabels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue,
+              { owner, repo, issue_number: number, per_page: 100 }
+            );
+            const currentLabelNames = currentLabels.map((l) => l.name);
+
+            for (const name of currentLabelNames) {
+              if (typeLabels.has(name) && name !== targetLabel) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: number,
+                    name,
+                  });
+                } catch (error) {
+                  console.log(`Failed to remove label "${name}":`, error?.message ?? error);
+                }
+              }
+            }
+
+            if (!currentLabelNames.includes(targetLabel)) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  labels: [targetLabel],
+                });
+              } catch (error) {
+                console.log(`Failed to add label "${targetLabel}":`, error?.message ?? error);
+              }
+            }


### PR DESCRIPTION
## 📌 Summary

- close #4

- Issue/PR 생성 경로(웹/CLI)와 무관하게 라벨과 담당자를 자동 지정합니다.
- 담당자(assignee)는 항상 `@maehwasoo`로 고정합니다.
- 제목 프리픽스(`[feat]` 등) 기반으로 타입 라벨을 1개만 유지합니다.

## 📄 Tasks

- [x] `.github/workflows/auto-triage.yml`를 추가합니다.
- [x] Issue 이벤트에서 assignee/label을 자동 지정합니다.
- [x] PR 이벤트에서 assignee/label을 자동 지정합니다.

## 🔍 To Reviewer

- 제목 프리픽스가 없을 때는 라벨을 변경하지 않고, 담당자만 지정하도록 처리했습니다.

## 📸 Screenshot

- N/A (워크플로우 추가입니다.)
