### PR TITLE
[deploy] CI 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect changed paths
         id: filter


### PR DESCRIPTION
## 📌 Summary

- close #3
- GitHub Actions로 CI 워크플로우를 추가합니다.
- Web(`apps/web`)은 PR/Push마다 항상 `lint`/`build`를 수행합니다.
- API(`apps/api`)는 변경 사항이 있을 때만 `test`를 수행합니다.

## 📄 Tasks

- [x] `.github/workflows/ci.yml` 추가
- [x] Node 20 + pnpm@10.12.0 고정
- [x] pnpm 캐시 설정
- [x] API 변경 감지 후 조건부 테스트 실행
- [x] Java 21 + Gradle 캐시 설정

## 🔍 To Reviewer

- `ci-web`은 `pnpm -C apps/web lint` / `pnpm -C apps/web build`를 항상 실행합니다.
- `ci-api`는 `apps/api/**` 변경이 감지될 때만 실행되며, `./gradlew test`를 수행합니다.
- required checks 강제는 브랜치 보호 규칙에서 `CI / ci-web`, `CI / ci-api`를 지정해야 합니다.

## 📸 Screenshot

-
