### PR TITLE
[fix] Swagger(OpenAPI) 빌드 오류 수정

### DIFF
--- a/apps/api/src/main/java/com/sopt/demoday/api/common/config/OpenApiConfig.java
+++ b/apps/api/src/main/java/com/sopt/demoday/api/common/config/OpenApiConfig.java
@@ -1,10 +1,10 @@
 package com.sopt.demoday.api.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
-import io.swagger.v3.oas.annotations.security.SecuritySchemeIn;
-import io.swagger.v3.oas.annotations.security.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.servers.Server;
 
 import org.springframework.context.annotation.Configuration;
@@ -25,9 +25,8 @@ import org.springframework.context.annotation.Configuration;
 	name = "SessionCookie",
 	type = SecuritySchemeType.APIKEY,
 	in = SecuritySchemeIn.COOKIE,
-	name = "sid",
+	paramName = "sid",
 	description = "HttpOnly session cookie. Cookie name can be changed via app.session.cookie-name."
 )
 public class OpenApiConfig {
 }
-


### PR DESCRIPTION
## Summary

- Swagger(OpenAPI) 설정 파일의 잘못된 import 경로를 수정합니다.
- `@SecurityScheme` 중복 `name` 설정을 `paramName`으로 교체해 컴파일 오류를 해결합니다.

## Tasks

- [x] CI `:compileJava` 실패 원인 수정

## Screenshot

-
