### PR TITLE
[fix] 로그인 UI 정렬 불일치 수정

### DIFF
--- a/apps/web/src/app/login/LoginPageClient.tsx
+++ b/apps/web/src/app/login/LoginPageClient.tsx
@@ -177,7 +177,7 @@ function TeamDropdown({
 
       {open ? (
         <div
-          className="absolute top-[calc(100%+8px)] left-0 z-20 w-full rounded-[4px] border border-[var(--color-black)] bg-[var(--color-black)] py-[12px]"
+          className="absolute top-[calc(100%+8px)] left-0 z-20 max-h-[360px] w-full overflow-y-auto overscroll-contain rounded-[4px] border border-[var(--color-black)] bg-[var(--color-black)] py-[12px]"
           role="listbox"
         >
           {TEAM_OPTIONS.map((option) => {


### PR DESCRIPTION
- close #87
- 로그인 CTA 라벨을 '다음'으로 통일합니다.
- 앱잼 팀 단계 detail 간격/정렬 및 드롭다운/placeholder 스타일을 디자인 기준으로 조정합니다.

## Tasks
- [ ] CTA 라벨 변경
- [ ] detail 간격/정렬 조정
- [ ] 드롭다운 리스트 배경/보더 조정
- [ ] placeholder 타이포 조정

## To Reviewer
- [ ] 디자인 기준 대비 확인 부탁드립니다.

## Screenshot
-