### PR TITLE
[feat] 웹 인앱 QR 스캔으로 도장 적립

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@sentry/nextjs": "^10.34.0",
     "@tailwindcss/vite": "^4.0.0",
+    "@zxing/browser": "^0.1.5",
     "motion": "^12.23.6",
     "next": "16.1.1",
     "qrcode": "^1.5.4",

--- a/apps/web/src/app/(tabs)/leaflet/LeafletPageClient.tsx
+++ b/apps/web/src/app/(tabs)/leaflet/LeafletPageClient.tsx
@@ -68,6 +68,10 @@ export default function LeafletPageClient() {
     router.replace(`/login?next=${encodeURIComponent(nextPath)}`);
   }, [nextPath, router]);
 
+  const openScan = useCallback(() => {
+    router.push('/leaflet/scan');
+  }, [router]);
+
   const loadProgress = useCallback(async () => {
     const response = await leafletProgressApi();
     setProgress(response);
@@ -159,6 +163,7 @@ export default function LeafletPageClient() {
         progressCount={progress?.completedCount ?? 0}
         totalCount={progress?.totalCount}
         completedStampKeys={completedStampKeys}
+        onScan={openScan}
       />
 
       {/* toast */}

--- a/apps/web/src/app/(tabs)/leaflet/scan/LeafletScanPageClient.tsx
+++ b/apps/web/src/app/(tabs)/leaflet/scan/LeafletScanPageClient.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import NavTop from '@/components/layout/nav-top/NavTop';
+
+type ScanStatus = 'idle' | 'scanning' | 'unsupported' | 'error';
+
+function extractLeafletCode(value: string, origin: string): string | null {
+  const text = value.trim();
+  if (!text) return null;
+
+  // Absolute URL
+  if (text.includes('://')) {
+    try {
+      const url = new URL(text);
+      return url.searchParams.get('code')?.trim() || text;
+    } catch {
+      return text;
+    }
+  }
+
+  // Relative URL (/leaflet?code=...) or any path-like string
+  if (text.startsWith('/') || text.includes('?')) {
+    try {
+      const url = new URL(text, origin);
+      return url.searchParams.get('code')?.trim() || text;
+    } catch {
+      return text;
+    }
+  }
+
+  // Plain code
+  return text;
+}
+
+export default function LeafletScanPageClient() {
+  const router = useRouter();
+
+  const [status, setStatus] = useState<ScanStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const [manualCode, setManualCode] = useState('');
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const controlsRef = useRef<{ stop: () => void } | null>(null);
+  const scannedRef = useRef(false);
+
+  const origin = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    return window.location.origin;
+  }, []);
+
+  useEffect(() => {
+    router.prefetch('/login');
+    router.prefetch('/leaflet');
+  }, [router]);
+
+  const goLeafletWithCode = useCallback(
+    (raw: string) => {
+      const code = extractLeafletCode(raw, origin);
+      if (!code) return;
+
+      router.replace(`/leaflet?code=${encodeURIComponent(code)}`);
+    },
+    [origin, router]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const start = async () => {
+      setErrorMessage(null);
+
+      if (typeof window === 'undefined') return;
+      if (!window.isSecureContext || !navigator.mediaDevices?.getUserMedia) {
+        setStatus('unsupported');
+        setErrorMessage('카메라는 HTTPS 환경에서만 사용할 수 있습니다.');
+        return;
+      }
+
+      const video = videoRef.current;
+      if (!video) return;
+
+      setStatus('scanning');
+
+      try {
+        const { BrowserQRCodeReader } = await import('@zxing/browser');
+        const reader = new BrowserQRCodeReader();
+
+        const controls = await reader.decodeFromVideoDevice(
+          undefined,
+          video,
+          (result, error, controls) => {
+            if (cancelled) return;
+            controlsRef.current = controls;
+
+            if (result && !scannedRef.current) {
+              scannedRef.current = true;
+              controls.stop();
+              goLeafletWithCode(result.getText());
+              return;
+            }
+
+            // ignore scan errors while scanning
+            void error;
+          }
+        );
+
+        if (cancelled) {
+          controls.stop();
+          return;
+        }
+
+        controlsRef.current = controls;
+      } catch (error) {
+        if (cancelled) return;
+        setStatus('error');
+        setErrorMessage(
+          '카메라 스캔을 시작할 수 없습니다. 코드 입력을 이용해 주세요.'
+        );
+        void error;
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      controlsRef.current?.stop();
+    };
+  }, [goLeafletWithCode]);
+
+  return (
+    <main className="bg-[var(--color-black)]">
+      <NavTop
+        variant="sub"
+        title="기록 스캔"
+        onBack={() => {
+          controlsRef.current?.stop();
+          router.back();
+        }}
+      />
+
+      <div className="px-[16px] pt-[16px]">
+        <div className="flex flex-col gap-[12px]">
+          <p className="body_r_14 text-[var(--color-gray-200)]">
+            카메라로 QR을 스캔하면 자동으로 리플렛에 기록됩니다.
+          </p>
+
+          <div className="overflow-hidden rounded-[12px] bg-[var(--color-gray-900)] p-[12px]">
+            <div className="relative aspect-square w-full overflow-hidden rounded-[8px] bg-[var(--color-black)]">
+              <video
+                ref={videoRef}
+                className="absolute inset-0 h-full w-full object-cover"
+                muted
+                playsInline
+              />
+
+              {status !== 'scanning' ? (
+                <div className="absolute inset-0 flex items-center justify-center px-[16px] text-center">
+                  <p className="body_r_14 text-[var(--color-gray-200)]">
+                    {errorMessage ??
+                      '스캔을 시작할 수 없습니다. 아래에서 코드를 입력해 주세요.'}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="mt-[8px] flex flex-col gap-[8px]">
+            <label className="caption_r_10 text-[var(--color-gray-400)]">
+              QR이 인식되지 않는다면 코드로 입력해 주세요.
+            </label>
+            <div className="flex gap-[8px]">
+              <input
+                className="body_r_14 h-[44px] w-full rounded-[8px] bg-[var(--color-gray-900)] px-[12px] text-[var(--color-white)] placeholder:text-[var(--color-gray-500)]"
+                placeholder="예: preview-amp"
+                value={manualCode}
+                onChange={(event) => setManualCode(event.target.value)}
+              />
+              <button
+                type="button"
+                className={[
+                  'head_b_14 h-[44px] shrink-0 rounded-[8px] px-[12px]',
+                  manualCode.trim()
+                    ? 'bg-[var(--color-37demo-red)] text-[var(--color-white)]'
+                    : 'cursor-not-allowed bg-[var(--color-gray-800)] text-[var(--color-gray-600)]',
+                  'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-white)]',
+                ].join(' ')}
+                disabled={!manualCode.trim()}
+                onClick={() => goLeafletWithCode(manualCode)}
+              >
+                확인
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/(tabs)/leaflet/scan/page.tsx
+++ b/apps/web/src/app/(tabs)/leaflet/scan/page.tsx
@@ -1,0 +1,5 @@
+import LeafletScanPageClient from './LeafletScanPageClient';
+
+export default function LeafletScanPage() {
+  return <LeafletScanPageClient />;
+}

--- a/apps/web/src/components/feature/leaflet-stamp/LeafletBottomPanel.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletBottomPanel.tsx
@@ -9,6 +9,7 @@ const SUNRISE_TEXT_MASK_SRC = '/assets/leaflet/icons/sunrise-text-mask.svg';
 type LeafletBottomPanelProgressProps = {
   current: number;
   total: number;
+  onScan?: () => void;
 };
 
 type LeafletBottomPanelCompleteProps = {
@@ -35,6 +36,7 @@ function getSunriseTextMaskStyle(): CSSProperties {
 function LeafletBottomPanelProgress({
   current,
   total,
+  onScan,
 }: LeafletBottomPanelProgressProps) {
   return (
     <div className="shadow_top flex h-[172px] w-full flex-col items-center gap-[24px] overflow-hidden rounded-tl-[32px] rounded-tr-[32px] bg-[var(--color-black)] px-0 pt-[8px] pb-0">
@@ -71,6 +73,8 @@ function LeafletBottomPanelProgress({
       <button
         type="button"
         className="relative h-[74px] w-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-white)]"
+        onClick={onScan}
+        disabled={!onScan}
       >
         <span
           aria-hidden

--- a/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
@@ -8,6 +8,8 @@ export type LeafletStampScreenProps = {
   progressCount: number;
   totalCount?: number;
   handleDown?: boolean;
+  // scan CTA handler
+  onScan?: () => void;
   // completed stamp keys
   completedStampKeys?: readonly LeafletStampKey[];
 };
@@ -32,6 +34,7 @@ export default function LeafletStampScreen({
   progressCount,
   totalCount = LEAFLET_STAMPS.length,
   handleDown,
+  onScan,
   completedStampKeys,
 }: LeafletStampScreenProps) {
   const completedKeys = completedStampKeys
@@ -67,6 +70,7 @@ export default function LeafletStampScreen({
             mode="progress"
             current={resolvedProgressCount}
             total={totalCount}
+            onScan={onScan}
           />
         )}
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.1.18(vite@7.3.1(@types/node@25.0.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@zxing/browser':
+        specifier: ^0.1.5
+        version: 0.1.5(@zxing/library@0.21.3)
       motion:
         specifier: ^12.23.6
         version: 12.26.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2145,6 +2148,18 @@ packages:
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  '@zxing/browser@0.1.5':
+    resolution: {integrity: sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==}
+    peerDependencies:
+      '@zxing/library': ^0.21.0
+
+  '@zxing/library@0.21.3':
+    resolution: {integrity: sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==}
+    engines: {node: '>= 10.4.0'}
+
+  '@zxing/text-encoding@0.9.0':
+    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -4820,6 +4835,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -7442,6 +7461,21 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
+
+  '@zxing/browser@0.1.5(@zxing/library@0.21.3)':
+    dependencies:
+      '@zxing/library': 0.21.3
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
+
+  '@zxing/library@0.21.3':
+    dependencies:
+      ts-custom-error: 3.3.1
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
+
+  '@zxing/text-encoding@0.9.0':
+    optional: true
 
   abort-controller@3.0.0:
     dependencies:
@@ -10559,6 +10593,8 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-custom-error@3.3.1: {}
 
   ts-dedent@2.2.0: {}
 


### PR DESCRIPTION
## 📌 Summary

- close #81
- 리플렛 바텀시트가 하단 탭바 바로 위에 붙도록 화면 높이를 조정합니다.
- 미로그인 시 로그인 페이지 이동 체감 개선을 위해 `/login`을 프리페치합니다.
- 웹 앱 내부에서 카메라로 QR을 스캔하여 `code`를 추출하고 리플렛 적립 플로우로 연결합니다.

## 📄 Tasks

- [x] 리플렛 바텀시트 위치 보정
- [x] 로그인 페이지 프리페치로 리다이렉트 체감 개선
- [x] QR 스캔(카메라) 및 코드 입력 fallback 제공
- [ ] iOS Safari 실기기 최종 점검

## 🔍 To Reviewer

- QR 스캔은 `@zxing/browser` 기반이며, 스캔 성공 시 `/leaflet?code=...`로 이동해 기존 claim 로직을 재사용합니다.

## 📸 Screenshot

-
