### PR TITLE
[fix] 리플렛 스캔 CTA 네비게이션 수정

### DIFF
--- a/apps/web/src/app/(tabs)/leaflet/LeafletPageClient.tsx
+++ b/apps/web/src/app/(tabs)/leaflet/LeafletPageClient.tsx
@@ -68,10 +68,6 @@ export default function LeafletPageClient() {
     router.replace(`/login?next=${encodeURIComponent(nextPath)}`);
   }, [nextPath, router]);
 
-  const openScan = useCallback(() => {
-    router.push('/leaflet/scan');
-  }, [router]);
-
   const loadProgress = useCallback(async () => {
     const response = await leafletProgressApi();
     setProgress(response);
@@ -163,7 +159,6 @@ export default function LeafletPageClient() {
         progressCount={progress?.completedCount ?? 0}
         totalCount={progress?.totalCount}
         completedStampKeys={completedStampKeys}
-        onScan={openScan}
       />
 
       {/* toast */}

--- a/apps/web/src/components/feature/leaflet-stamp/LeafletBottomPanel.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletBottomPanel.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties } from 'react';
 
+import Link from 'next/link';
+
 import { QrIcon, SunriseIcon } from '@/components/icons';
 import { ProgressBar } from '@/components/ui';
 
@@ -9,7 +11,6 @@ const SUNRISE_TEXT_MASK_SRC = '/assets/leaflet/icons/sunrise-text-mask.svg';
 type LeafletBottomPanelProgressProps = {
   current: number;
   total: number;
-  onScan?: () => void;
 };
 
 type LeafletBottomPanelCompleteProps = {
@@ -36,7 +37,6 @@ function getSunriseTextMaskStyle(): CSSProperties {
 function LeafletBottomPanelProgress({
   current,
   total,
-  onScan,
 }: LeafletBottomPanelProgressProps) {
   return (
     <div className="shadow_top flex h-[172px] w-full flex-col items-center gap-[24px] overflow-hidden rounded-tl-[32px] rounded-tr-[32px] bg-[var(--color-black)] px-0 pt-[8px] pb-0">
@@ -70,11 +70,9 @@ function LeafletBottomPanelProgress({
         </div>
       </div>
 
-      <button
-        type="button"
+      <Link
+        href="/leaflet/scan"
         className="relative h-[74px] w-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-white)]"
-        onClick={onScan}
-        disabled={!onScan}
       >
         <span
           aria-hidden
@@ -90,7 +88,7 @@ function LeafletBottomPanelProgress({
             </span>
           </span>
         </span>
-      </button>
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
@@ -8,8 +8,6 @@ export type LeafletStampScreenProps = {
   progressCount: number;
   totalCount?: number;
   handleDown?: boolean;
-  // scan CTA handler
-  onScan?: () => void;
   // completed stamp keys
   completedStampKeys?: readonly LeafletStampKey[];
 };
@@ -34,7 +32,6 @@ export default function LeafletStampScreen({
   progressCount,
   totalCount = LEAFLET_STAMPS.length,
   handleDown,
-  onScan,
   completedStampKeys,
 }: LeafletStampScreenProps) {
   const completedKeys = completedStampKeys
@@ -70,7 +67,6 @@ export default function LeafletStampScreen({
             mode="progress"
             current={resolvedProgressCount}
             total={totalCount}
-            onScan={onScan}
           />
         )}
       </div>


### PR DESCRIPTION
## 📌 Summary

- 리플렛 바텀시트의 “기록 스캔하기” CTA가 클릭 시 이동하지 않던 문제를 수정합니다.
- JS hydration(초기 JS 연결) 여부와 무관하게 `/leaflet/scan`으로 이동되도록 Link 기반으로 변경합니다.
- ref #81

## 📄 Tasks

- [x] CTA를 button(onClick) → Link(href)로 변경합니다.
- [x] 불필요해진 onScan prop chain을 제거합니다.
- [x] `pnpm --filter sopt-37th-demoday lint`를 통과합니다(경고만 존재).

## 🔍 To Reviewer

- `/leaflet`에서 “기록 스캔하기” 클릭 시 `/leaflet/scan` 이동을 확인 부탁드립니다.

## 📸 Screenshot

-
