### PR TITLE
[fix] 리플렛 헤더 로고 크기 조정

### DIFF
--- a/apps/web/src/components/layout/nav-top/NavTop.tsx
+++ b/apps/web/src/components/layout/nav-top/NavTop.tsx
@@ -42,10 +42,13 @@ export default function NavTop(props: NavTopProps) {
     );
   }
 
+  const showQr = Boolean(props.showLeafletStampQrMenu);
+
   return (
     <header
       className={[
-        'shadow_bottom relative flex h-[56px] w-full items-center justify-center bg-[var(--color-black)]',
+        'shadow_bottom relative h-[56px] w-full bg-[var(--color-black)]',
+        showQr ? '' : 'flex items-center justify-center',
         props.className,
       ]
         .filter(Boolean)
@@ -54,10 +57,14 @@ export default function NavTop(props: NavTopProps) {
       <img
         alt="SYSTEM UPDATE : SUNRISE"
         src="/assets/leaflet/icons/sunrise-text-mask.svg"
-        className="h-[38.5px] w-[286px]"
+        className={
+          showQr
+            ? 'absolute top-1/2 left-[24px] h-[14.0996px] -translate-y-1/2'
+            : 'h-[38.5px] w-[286px]'
+        }
       />
 
-      {props.showLeafletStampQrMenu ? <LeafletStampQrMenu /> : null}
+      {showQr ? <LeafletStampQrMenu /> : null}
     </header>
   );
 }


### PR DESCRIPTION
## 📌 Summary

- close #106
- 리플렛 헤더에서 로고를 좌측 배치하고 높이를 조정합니다.

## 📄 Tasks

- [x] 리플렛 헤더 로고 높이를 조정합니다.
- [x] 우측 QR 아이콘 표시 시 로고 좌측 정렬을 적용합니다.
- [x] lint를 확인합니다.

## 🔍 To Reviewer

- 리플렛 헤더에서 로고가 의도한 크기로 보이는지 확인 부탁드립니다.

## 📸 Screenshot

-
