### PR TITLE
[fix] 홈 행사 개요 일시 시간 수정

### DIFF
--- a/src/app/(tabs)/page.tsx
+++ b/src/app/(tabs)/page.tsx
@@ -93,7 +93,7 @@ export default function Home() {
                 <div className="body_r_14 flex w-[199px] shrink-0 flex-col gap-[6px] text-[var(--color-white)]">
                   <p>SOPT 37기 앱잼 데모데이 : SUNRISE</p>
                   <p className="text-[var(--color-gray-100)]">마곡 NSP홀</p>
-                  <p>2025.01.24(토) 10:30 ~ 17:00</p>
+                  <p>2025.01.24(토) 10:20 ~ 17:00</p>
                 </div>
               </div>
             </section>


### PR DESCRIPTION
## 📌 Summary

- close #116
- 홈 "행사 개요" 섹션의 일시 시작 시간을 10:30 → 10:20으로 수정합니다.

## 📄 Tasks

- [x] 홈 행사 개요 일시 시간 수정 (10:30 → 10:20)
- [ ] 로컬에서 홈 페이지 렌더링 확인

## 🔍 To Reviewer

- 문구(일시) 변경만 포함되어 있습니다. 다른 시간 표기 위치가 있는지 한 번만 확인 부탁드립니다.

## 📸 Screenshot

-
