### PR TITLE
[feat] 스탬프 완료 심볼 랜덤 노출

### DIFF
--- a/apps/web/src/components/feature/leaflet-stamp/LeafletStampTile.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletStampTile.tsx
@@ -1,8 +1,10 @@
-import type { CSSProperties } from 'react';
+'use client';
+
+import { useMemo, type CSSProperties } from 'react';
 
 import {
   LEAFLET_STAMP_ASSETS,
-  LEAFLET_STAMP_SYMBOL_BY_KEY,
+  LEAFLET_STAMP_SYMBOLS,
 } from './leafletStamp.assets';
 import type { LeafletStamp, LeafletStampKey } from './leafletStamp.constants';
 
@@ -222,6 +224,11 @@ function StampLogoLayers({ stampKey }: { stampKey: LeafletStampKey }) {
   }
 }
 
+function getRandomCompletedSymbolSrc() {
+  const index = Math.floor(Math.random() * LEAFLET_STAMP_SYMBOLS.length);
+  return LEAFLET_STAMP_SYMBOLS[index] ?? LEAFLET_STAMP_SYMBOLS[0];
+}
+
 export default function LeafletStampTile({
   stamp,
   completed,
@@ -232,7 +239,10 @@ export default function LeafletStampTile({
       ? LEAFLET_STAMP_ASSETS.stampBaseDefaultMakers
       : LEAFLET_STAMP_ASSETS.stampBaseDefault;
 
-  const symbolSrc = LEAFLET_STAMP_SYMBOL_BY_KEY[stamp.key];
+  const symbolSrc = useMemo(() => {
+    if (!completed) return LEAFLET_STAMP_SYMBOLS[0];
+    return getRandomCompletedSymbolSrc();
+  }, [completed, stamp.key]);
 
   return (
     <div

--- a/apps/web/src/components/feature/leaflet-stamp/leafletStamp.assets.ts
+++ b/apps/web/src/components/feature/leaflet-stamp/leafletStamp.assets.ts
@@ -1,5 +1,3 @@
-import type { LeafletStampKey } from './leafletStamp.constants';
-
 const STAMP_ASSET_ROOT = '/assets/leaflet/stamps';
 
 export const LEAFLET_STAMP_ASSETS = {
@@ -39,17 +37,8 @@ export const LEAFLET_STAMP_ASSETS = {
   symbolC: `${STAMP_ASSET_ROOT}/stamp-symbol-c.svg`,
 } as const;
 
-export const LEAFLET_STAMP_SYMBOL_BY_KEY: Record<LeafletStampKey, string> = {
-  amp: LEAFLET_STAMP_ASSETS.symbolA,
-  carena: LEAFLET_STAMP_ASSETS.symbolA,
-  cherrish: LEAFLET_STAMP_ASSETS.symbolB,
-  clustar: LEAFLET_STAMP_ASSETS.symbolC,
-  snappin: LEAFLET_STAMP_ASSETS.symbolB,
-  comfit: LEAFLET_STAMP_ASSETS.symbolB,
-  flint: LEAFLET_STAMP_ASSETS.symbolC,
-  kareer: LEAFLET_STAMP_ASSETS.symbolA,
-  smashing: LEAFLET_STAMP_ASSETS.symbolC,
-  kiero: LEAFLET_STAMP_ASSETS.symbolA,
-  poti: LEAFLET_STAMP_ASSETS.symbolB,
-  makers: LEAFLET_STAMP_ASSETS.symbolC,
-};
+export const LEAFLET_STAMP_SYMBOLS = [
+  LEAFLET_STAMP_ASSETS.symbolA,
+  LEAFLET_STAMP_ASSETS.symbolB,
+  LEAFLET_STAMP_ASSETS.symbolC,
+] as const;


### PR DESCRIPTION
## 📌 Summary

- close #122
- 완료된 스탬프 타일의 완료 심볼을 A/B/C 중 랜덤으로 노출합니다.

## 📄 Tasks

- [ ] 완료 심볼 고정 매핑을 제거하고 랜덤 선택으로 변경합니다.

## 🔍 To Reviewer

- 완료된 도장(스탬프)에서 심볼이 팀 고정이 아닌 랜덤으로 표시되는지 확인 부탁드립니다.

## 📸 Screenshot

-
