### PR TITLE
[fix] QR 팝업 기록 인증 QR 코드 개행 수정

### DIFF
--- a/apps/web/src/components/layout/nav-top/components/LeafletStampQrMenu.client.tsx
+++ b/apps/web/src/components/layout/nav-top/components/LeafletStampQrMenu.client.tsx
@@ -123,7 +123,7 @@ export default function LeafletStampQrMenu() {
       {open ? (
         <div
           className={[
-            'shadow_bottom absolute top-[56px] right-0 z-[70] min-h-[219px] w-[167px] overflow-hidden',
+            'shadow_bottom absolute top-[56px] right-0 z-[70] min-h-[219px] w-[200px] overflow-hidden',
             'flex flex-col items-center gap-[16px] bg-[var(--color-black)] px-[16px] pt-[12px] pb-[16px]',
             'rounded-bl-[32px]',
           ].join(' ')}
@@ -132,7 +132,7 @@ export default function LeafletStampQrMenu() {
         >
           <div className="flex w-full items-center gap-[8px]">
             <QrIcon className="h-[24px] w-[24px] text-[var(--color-white)]" />
-            <p className="head_b_16 text-[var(--color-white)]">
+            <p className="head_b_16 whitespace-nowrap text-[var(--color-white)]">
               기록 인증 QR코드
             </p>
           </div>


### PR DESCRIPTION
## 📌 Summary

- close #125
- 리플렛 QR 팝업의 `기록 인증 QR코드` 텍스트가 한 줄로 보이도록 처리합니다.
- 팝업 너비를 늘려 제목이 개행되지 않도록 수정합니다.

## 📄 Tasks

- [x] 팝업 제목에 `whitespace-nowrap`를 적용합니다.
- [x] 팝업 너비를 조정하여 제목 줄바꿈을 방지합니다.

## 🔍 To Reviewer

- 리플렛 페이지에서 QR 아이콘 클릭 후, 팝업 제목이 한 줄로 표시되는지 확인 부탁드립니다.

## 📸 Screenshot

-
