### PR TITLE
[fix] 홈 행사 개요 일시 시간 수정

### DIFF
--- a/apps/web/src/app/(tabs)/page.tsx
+++ b/apps/web/src/app/(tabs)/page.tsx
@@ -99,7 +99,7 @@ export default function Home() {
                 <div className="body_r_14 flex min-w-0 flex-1 flex-col gap-[6px] text-[var(--color-white)]">
                   <p>SOPT 37기 앱잼 데모데이 : SUNRISE</p>
                   <p className="text-[var(--color-gray-100)]">마곡 NSP홀</p>
-                  <p>2026.01.24(토) 10:30 ~ 17:00</p>
+                  <p>2026.01.24(토) 10:20 ~ 17:00</p>
                 </div>
               </div>
             </section>


### PR DESCRIPTION
## 📌 Summary

- close #116
- 홈 화면 행사 개요 '일시' 시간을 10:20으로 수정합니다.
- develop 기준 날짜(2026.01.24)는 유지하고 시간만 변경합니다.

## 📄 Tasks

- [x] 홈 화면 행사 개요 일시 텍스트 수정

## 🔍 To Reviewer

- 변경 범위는 텍스트 1줄입니다.
- 기존에 main으로 잘못 머지된 변경을 되돌린 뒤 develop에 재적용하는 PR입니다.

## 📸 Screenshot

-
