### PR TITLE
[fix] 프로덕트 탭 헤더 비침 수정

### DIFF
--- a/apps/web/src/app/(tabs)/products/ProductsPageClient.tsx
+++ b/apps/web/src/app/(tabs)/products/ProductsPageClient.tsx
@@ -37,7 +37,7 @@ export default function ProductsPageClient() {
   return (
     <>
       {/* filters */}
-      <section className="shadow_bottom sticky top-0 z-40 flex flex-col items-center gap-[16px] bg-[var(--color-black-overlay)] px-0 pt-[calc(var(--safe-area-top)+8px)] pb-[16px] backdrop-blur-md">
+      <section className="shadow_bottom sticky top-0 z-40 flex flex-col items-center gap-[16px] bg-[var(--color-black)] px-0 pt-[calc(var(--safe-area-top)+8px)] pb-[16px] backdrop-blur-md">
         <Tabs
           value={activeTab}
           onValueChange={(value) => {


### PR DESCRIPTION
## 📌 Summary

- close #134
- 프로덕트 탭 상단 sticky 필터 헤더의 배경을 불투명으로 변경하여 스크롤 시 비침을 제거합니다.

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)
> - #134

## 📄 Tasks

- [x] 프로덕트 탭 상단 sticky 헤더 배경을 `--color-black`으로 변경합니다.

## 🔍 To Reviewer

- 스크롤 시 헤더 비침이 제거되었는지 확인 부탁드립니다.

## 📸 Screenshot

-
