### PR TITLE
[fix] 프로덕트 상세 레이아웃 여백/팀원 목록 개선

### DIFF
--- a/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
+++ b/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
@@ -129,16 +129,16 @@ export default function ProductDetailPageClient({
                   </div>
                 </div>
 
-                <div className="flex w-full items-center justify-center border-b border-solid border-[var(--color-gray-800)] px-0 pt-0 pb-[12px]">
-                  <p className="body_r_14 h-[60px] flex-1 text-[var(--color-white)]">
+                <div className="flex w-full items-center justify-center border-b border-solid border-[var(--color-gray-800)] px-0 pt-0 pb-[16px]">
+                  <p className="body_r_14 flex-1 text-[var(--color-white)]">
                     {product.description}
                   </p>
                 </div>
               </div>
 
               {memberRows.length ? (
-                <div className="flex items-end gap-[16px]">
-                  <div className="flex w-[79px] flex-col items-start">
+                <div className="flex w-full items-end gap-[16px]">
+                  <div className="flex w-[90px] flex-col items-start">
                     {memberRows.map((row) => {
                       const meta = ROLE_META[row.role];
 
@@ -165,7 +165,7 @@ export default function ProductDetailPageClient({
                     })}
                   </div>
 
-                  <div className="body_r_14 flex w-[147px] flex-col items-start gap-[4px] text-[var(--color-gray-300)]">
+                  <div className="body_r_14 flex min-w-0 flex-1 flex-col items-start gap-[4px] text-[var(--color-gray-300)]">
                     {memberRows.map((row) => {
                       const membersText = row.members.join(' ');
 


### PR DESCRIPTION
## 📌 Summary

- close #138
- 프로덕트 상세 설명 영역의 고정 높이를 제거하고 상/하 여백을 동일하게 맞춥니다.
- 팀원 목록에서 파트/인원 컬럼 너비를 조정하여 한 줄 배치가 유지되도록 합니다.

## 📄 Tasks

- [x] 설명 영역 하단 여백을 상단과 맞춥니다.
- [x] 설명 텍스트 높이 고정을 제거합니다.
- [x] 팀원 목록 컬럼 너비를 조정합니다.

## 🔍 To Reviewer

- 설명이 짧은/긴 케이스에서 카드 높이가 자연스럽게 변하는지 확인 부탁드립니다.
- 팀원 이름이 길 때 줄바꿈이 의도대로인지 확인 부탁드립니다.

## 📸 Screenshot

-
