### PR TITLE
[feat] 리플렛 완료 바텀시트 드래그 다운

### DIFF
--- a/apps/web/src/app/(tabs)/leaflet/LeafletPageClient.tsx
+++ b/apps/web/src/app/(tabs)/leaflet/LeafletPageClient.tsx
@@ -48,6 +48,7 @@ export default function LeafletPageClient() {
   const retryRef = useRef<(() => void) | null>(null);
 
   const [loading, setLoading] = useState(false);
+  const [completeHandleDown, setCompleteHandleDown] = useState(false);
 
   const nextPath = useMemo(() => {
     if (pendingCode) {
@@ -81,6 +82,9 @@ export default function LeafletPageClient() {
 
     const response = await leafletClaimApi({ code });
     setProgress(response);
+    if (response.completedCount >= response.totalCount) {
+      setCompleteHandleDown(false);
+    }
 
     trackEvent('leaflet_claim', { status: 'success' });
 
@@ -161,11 +165,17 @@ export default function LeafletPageClient() {
     return progress.completedStampKeys.filter(isLeafletStampKey);
   }, [progress]);
 
+  const isComplete = Boolean(
+    progress && progress.completedCount >= progress.totalCount
+  );
+
   return (
     <>
       <LeafletStampScreen
         progressCount={progress?.completedCount ?? 0}
         totalCount={progress?.totalCount}
+        handleDown={isComplete ? completeHandleDown : undefined}
+        onHandleDownChange={isComplete ? setCompleteHandleDown : undefined}
         completedStampKeys={completedStampKeys}
       />
 

--- a/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import LeafletBottomPanel from './LeafletBottomPanel';
 import { LEAFLET_STAMPS } from './leafletStamp.constants';
 import type { LeafletStampKey } from './leafletStamp.constants';
@@ -8,6 +10,7 @@ export type LeafletStampScreenProps = {
   progressCount: number;
   totalCount?: number;
   handleDown?: boolean;
+  onHandleDownChange?: (nextHandleDown: boolean) => void;
   // completed stamp keys
   completedStampKeys?: readonly LeafletStampKey[];
 };
@@ -32,6 +35,7 @@ export default function LeafletStampScreen({
   progressCount,
   totalCount = LEAFLET_STAMPS.length,
   handleDown,
+  onHandleDownChange,
   completedStampKeys,
 }: LeafletStampScreenProps) {
   const completedKeys = completedStampKeys
@@ -61,7 +65,11 @@ export default function LeafletStampScreen({
       {/* bottom sheets */}
       <div className="absolute bottom-0 left-0 w-full">
         {isComplete ? (
-          <LeafletBottomPanel mode="complete" handleDown={handleDown} />
+          <LeafletBottomPanel
+            mode="complete"
+            handleDown={handleDown}
+            onHandleDownChange={onHandleDownChange}
+          />
         ) : (
           <LeafletBottomPanel
             mode="progress"


### PR DESCRIPTION
## 📌 Summary

- close #136
- 리플렛 12/12 달성 시 완료 바텀시트를 자동으로 노출합니다.
- 바텀시트 드래그 다운 시 시트를 내리고, 스탬프 그리드(완료 상태)를 다시 노출합니다.

## 📄 Tasks

- [x] 완료 바텀시트 드래그 다운/업 상호작용을 추가합니다.
- [x] 리플렛 완료 상태에서 바텀시트 상태를 페이지에 연결합니다.

## 🔍 To Reviewer

- [ ] 리플렛에서 11/12 상태로 마지막 스탬프를 적립했을 때, 완료 바텀시트가 즉시 올라오는지 확인해 주세요.
- [ ] 완료 바텀시트를 아래로 드래그했을 때, 시트가 내려가면서 12/12 스탬프가 모두 찍힌 그리드가 노출되는지 확인해 주세요.

## 📸 Screenshot

-
