### PR TITLE
[fix] 프로덕트 상세 파트/CTA 오버플로우 수정

### DIFF
--- a/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
+++ b/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
@@ -138,7 +138,7 @@ export default function ProductDetailPageClient({
 
               {memberRows.length ? (
                 <div className="flex w-full items-end gap-[16px]">
-                  <div className="flex w-[90px] flex-col items-start">
+                  <div className="flex flex-none flex-col items-start">
                     {memberRows.map((row) => {
                       const meta = ROLE_META[row.role];
 
@@ -191,7 +191,7 @@ export default function ProductDetailPageClient({
                 });
               }}
             >
-              <div className="absolute top-[14px] left-[16px] flex w-[228px] flex-col items-start">
+              <div className="absolute top-[14px] right-[78px] left-[16px] flex flex-col items-start">
                 <div className="flex items-center gap-[8px]">
                   <span className="h-[24px] w-[24px] text-[var(--color-37demo-red)]">
                     <SunriseIcon />
@@ -201,7 +201,7 @@ export default function ProductDetailPageClient({
                   </p>
                 </div>
 
-                <div className="head_b_16 mt-0 text-[var(--color-white)]">
+                <div className="head_b_16 mt-0 break-keep text-[var(--color-white)]">
                   <p className="mb-0">
                     온라인 리플렛을 통해 부스별 도장을 찍고
                   </p>


### PR DESCRIPTION
## 📌 Summary

- close #141
- 팀원 목록에서 파트 컬럼을 고정 폭이 아닌 내용 기반 너비로 변경합니다.
- CTA(온라인 리플렛 안내) 문구가 작은 화면에서도 영역 밖으로 넘어가지 않도록 대응합니다.

## 📄 Tasks

- [x] 파트 컬럼 고정 너비 제거
- [x] CTA 텍스트 영역을 가변 폭으로 변경
- [x] 문구 줄바꿈/오버플로우 대응

## 🔍 To Reviewer

- 360px/320px 등 작은 화면에서 CTA 문구와 우측 화살표가 겹치지 않는지 확인 부탁드립니다.
- 파트명이 긴 경우(예: 안드로이드)에도 레이아웃이 의도대로인지 확인 부탁드립니다.

## 📸 Screenshot

-
