### PR TITLE
[fix] 리플렛 완료 바텀시트 하단 겹침 수정

### DIFF
--- a/apps/web/src/components/feature/leaflet-stamp/LeafletBottomPanel.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletBottomPanel.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import { QrIcon, SunriseIcon } from '@/components/icons';
 import { ProgressBar } from '@/components/ui';
 
-const SUNRISE_CIRCLE_SRC = '/assets/leaflet/patterns/sunrise-circle.webp';
 const SUNRISE_TEXT_MASK_SRC = '/assets/leaflet/icons/sunrise-text-mask.svg';
 const DONE_BOTTOM_GRADIENT_SRC =
   '/assets/leaflet/patterns/leaflet-done-background.png';
@@ -215,34 +214,6 @@ function LeafletBottomPanelComplete({
           <p className="black_bk_20 text-center text-[var(--color-white)]">
             DIVE SOPT 데모데이 업데이트 완료
           </p>
-        </div>
-      </div>
-
-      {/* sunrise circles */}
-      <div
-        aria-hidden
-        className="absolute top-[330px] left-0 z-0 h-[98px] w-full overflow-hidden"
-      >
-        <div className="absolute top-0 left-[-232.05px] h-[114.874px] w-[852.233px] opacity-15">
-          <img
-            alt=""
-            className="h-full w-full object-cover"
-            src={SUNRISE_CIRCLE_SRC}
-          />
-        </div>
-        <div className="absolute top-[12.61px] left-[-161.03px] h-[95.728px] w-[710.194px] opacity-25">
-          <img
-            alt=""
-            className="h-full w-full object-cover"
-            src={SUNRISE_CIRCLE_SRC}
-          />
-        </div>
-        <div className="absolute top-[23.62px] left-[-101.85px] h-[79.773px] w-[591.828px] opacity-50">
-          <img
-            alt=""
-            className="h-full w-full object-cover"
-            src={SUNRISE_CIRCLE_SRC}
-          />
         </div>
       </div>
 


### PR DESCRIPTION
## 📌 Summary

- close #142
- 완료 바텀시트 하단 그라데이션 이미지가 기존 장식 레이어에 가려/겹쳐 보이던 문제를 수정합니다.

## 📄 Tasks

- 완료 바텀시트에서 sunrise circles 레이어를 제거합니다.
- 하단 98px 영역이 이미지 그라데이션만 보이도록 조정합니다.

## 🔍 To Reviewer

- `/leaflet` 완료(12/12) 상태에서 하단 그라데이션이 블록형으로 보이지 않는지 확인 부탁드립니다.

## 📸 Screenshot

-
