### PR TITLE
[fix] 리플렛 완료 바텀시트 뒤 스탬프 레이어 유지

### DIFF
--- a/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
+++ b/apps/web/src/components/feature/leaflet-stamp/LeafletStampScreen.tsx
@@ -53,12 +53,10 @@ export default function LeafletStampScreen({
       <div className="px-[23px] pt-[25px]">
         <div className="flex flex-col items-center gap-[24px]">
           <LeafletStampDetailCard />
-          {!isComplete || handleDown ? (
-            <LeafletStampGrid
-              stamps={LEAFLET_STAMPS}
-              completedKeys={completedKeys}
-            />
-          ) : null}
+          <LeafletStampGrid
+            stamps={LEAFLET_STAMPS}
+            completedKeys={completedKeys}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## 📌 Summary

- close #143
- 리플렛 완료 바텀시트를 드래그할 때도 스탬프(도장) 그리드 레이어가 유지되도록 합니다.

## 📄 Tasks

- [x] 완료 상태에서도 스탬프 그리드를 항상 렌더링하도록 수정합니다.

## 🔍 To Reviewer

- [ ] 12/12 완료 바텀시트가 올라온 상태에서 아래로 드래그할 때, 뒤가 비어 보이지 않고 스탬프가 유지되는지 확인해 주세요.
- [ ] 드래그 다운 후에도 스탬프 + 내려가 있는 완료 바텀시트 상태가 자연스럽게 보이는지 확인해 주세요.

## 📸 Screenshot

-
