### PR TITLE
[fix] 프로덕트 상세 팀원 여백/CTA 화살표 보정

### DIFF
--- a/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
+++ b/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 
 import {
   AndroidIcon,
-  ArrowRightIcon,
   DesignIcon,
   IosIcon,
   PlanningIcon,
@@ -117,7 +116,7 @@ export default function ProductDetailPageClient({
               )}
             </div>
 
-            <div className="flex min-h-[272px] w-full flex-col items-start gap-[12px] rounded-[2px] bg-[var(--color-gray-900)] p-[12px]">
+            <div className="flex w-full flex-col items-start gap-[12px] rounded-[2px] bg-[var(--color-gray-900)] p-[12px]">
               <div className="flex w-full flex-col items-start gap-[16px]">
                 <div className="flex items-start gap-[8px]">
                   <p className="head_b_20 text-[var(--color-white)]">
@@ -210,7 +209,19 @@ export default function ProductDetailPageClient({
               </div>
 
               <div className="absolute top-1/2 right-[22px] flex h-[56px] w-[56px] -translate-y-1/2 items-center justify-center text-[var(--color-37demo-red)]">
-                <ArrowRightIcon width={10} height={18} />
+                <svg
+                  width={10}
+                  height={18}
+                  viewBox="0 0 23.3333 42"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden
+                >
+                  <path
+                    d="M2.3926 42L23.3333 21L2.3926 0L0 2.39945L18.548 21L0 39.6005L2.3926 42Z"
+                    fill="currentColor"
+                  />
+                </svg>
               </div>
             </a>
           </section>


### PR DESCRIPTION
## 📌 Summary

- close #147
- 프로덕트 상세 팀원 카드의 불필요한 고정 여백을 제거합니다.
- CTA 화살표를 SVG로 교체하여 디자인 대비 작아 보이던 문제를 개선합니다.

## 📄 Tasks

- [x] 팀원 카드 높이 고정 완화
- [x] CTA 화살표 SVG 적용

## 🔍 To Reviewer

- 팀원 목록이 1~N줄인 케이스에서 카드 여백이 자연스러운지 확인 부탁드립니다.
- CTA 화살표 크기/정렬이 의도대로인지 확인 부탁드립니다.

## 📸 Screenshot

-
