### PR TITLE
[fix] 팀명 표기 수정

### DIFF
--- a/apps/web/src/data/teams.ts
+++ b/apps/web/src/data/teams.ts
@@ -32,7 +32,7 @@ export const TEAM_LIST: readonly Team[] = [
   },
   {
     key: 'carena',
-    displayName: 'CareNA',
+    displayName: '케어나',
     category: '건강/피트니스',
     shortDescription: '건강검진 결과를 쉽게, 관리까지 한 번에',
     track: 'appjam',
@@ -74,7 +74,7 @@ export const TEAM_LIST: readonly Team[] = [
   },
   {
     key: 'clustar',
-    displayName: 'cluSTAR',
+    displayName: 'CLUSTAR',
     category: '생산성',
     shortDescription: '흩어진 메모를 빛나는 결과물로',
     track: 'appjam',


### PR DESCRIPTION
## 📌 Summary

- close #151
- 프로덕트/드롭다운 팀명 표기에서 `cluSTAR` → `CLUSTAR` 로 수정합니다.
- 프로덕트/드롭다운 팀명 표기에서 `CareNA` → `케어나` 로 수정합니다.

## 📄 Tasks

- [x] 팀 목록 데이터의 displayName을 수정합니다.
- [x] 웹 빌드(`apps/web`)가 통과하는지 확인합니다.

## 🔍 To Reviewer

- 로그인 페이지의 팀 선택 드롭다운, 프로덕트 목록/상세에서 팀명이 의도대로 표시되는지 확인 부탁드립니다.

## 📸 Screenshot

-
