### PR TITLE
[fix] Leaflet 완료 바텀시트 핸들다운 스냅 수정

### DIFF
--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -127,11 +127,11 @@
 
   @keyframes leaflet-bottom-panel-slide-up {
     from {
-      transform: translateY(256px);
+      height: 172px;
     }
 
     to {
-      transform: translateY(0);
+      height: 428px;
     }
   }
 


### PR DESCRIPTION
## 📌 Summary

- close #150
- 완료 바텀시트 드래그 다운 시 172px 높이로 스냅되도록 수정합니다.

## 📄 Tasks

- [ ] 완료 바텀시트 핸들다운 스냅을 height 기반으로 조정합니다.
- [ ] 드래그 다운 시 바텀시트가 화면에서 사라지지 않도록 수정합니다.
- [ ] lint/build를 통과합니다.

## 🔍 To Reviewer

- "전부 완료" 상태에서 드래그 다운 시 172px 노출 상태로 멈추는지 확인 부탁드립니다.

## 📸 Screenshot

-
