### PR TITLE
[fix] 로그인 팀 드롭다운 화살표 정렬 수정

### DIFF
--- a/apps/web/src/app/login/LoginPageClient.tsx
+++ b/apps/web/src/app/login/LoginPageClient.tsx
@@ -166,10 +166,15 @@ function TeamDropdown({
           {selected ? selected.label : '소속 팀을 선택해 주세요'}
         </span>
 
-        <span className="relative h-[24px] w-[24px]">
-          <span className={open ? 'block rotate-90' : 'block -rotate-90'}>
-            <img alt="" className="h-[18px] w-[10px]" src={CHEVRON_ICON_SRC} />
-          </span>
+        <span className="flex h-[24px] w-[24px] items-center justify-center">
+          <img
+            alt=""
+            className={[
+              'h-[18px] w-[10px]',
+              open ? 'rotate-90' : '-rotate-90',
+            ].join(' ')}
+            src={CHEVRON_ICON_SRC}
+          />
         </span>
       </button>
 


### PR DESCRIPTION
## 📌 Summary

- close #154
- 로그인 팀 선택 드롭다운 화살표 중앙 정렬 고정

## 📄 Tasks

- [x] 화살표 래퍼 중앙 정렬 적용
- [x] 회전 적용 대상을 `<img>`로 변경
- [x] `pnpm -C apps/web lint` 확인 (warning only)

## 🔍 To Reviewer

- 드롭다운 open/close 시 화살표가 24x24 정중앙을 유지하는지 확인 부탁드립니다.

## 📸 Screenshot

-
