### PR TITLE
[style] 섹션 Fade-in 애니메이션 적용

### DIFF
--- a/apps/web/src/app/(tabs)/page.tsx
+++ b/apps/web/src/app/(tabs)/page.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 
+import FadeInView from '@/components/common/FadeInView';
 import Divider from '@/components/feature/section-header/Divider';
 import TagMain from '@/components/feature/section-header/TagMain';
 import InstagramIcon from '@/components/icons/InstagramIcon';
@@ -32,244 +33,259 @@ export default function Home() {
         <section className="flex w-full flex-col items-center gap-[40px]">
           <Divider />
 
-          <section className="flex w-full flex-col items-center gap-[24px] px-[24px]">
-            <div className="flex w-[286.002px] flex-col items-center gap-[6px]">
-              <div className="relative h-[16.002px] w-[286px] shrink-0 overflow-visible">
-                <Image
-                  src="/assets/figma/main/img_logo.png"
-                  alt=""
-                  fill
-                  className="object-contain"
-                  sizes="286px"
-                />
+          <FadeInView
+            className="w-full"
+            distance={50}
+            duration={0.8}
+            amount={0.3}
+          >
+            <section className="flex w-full flex-col items-center gap-[24px] px-[24px]">
+              <div className="flex w-[286.002px] flex-col items-center gap-[6px]">
+                <div className="relative h-[16.002px] w-[286px] shrink-0 overflow-visible">
+                  <Image
+                    src="/assets/figma/main/img_logo.png"
+                    alt=""
+                    fill
+                    className="object-contain"
+                    sizes="286px"
+                  />
+                </div>
+                <p className="head_b_14 text-[var(--color-white)]">
+                  치열한 기록들로 띄워낸 가장 완벽한 아침
+                </p>
               </div>
-              <p className="head_b_14 text-[var(--color-white)]">
-                치열한 기록들로 띄워낸 가장 완벽한 아침
-              </p>
-            </div>
 
-            <div className="body_r_14 w-full text-[var(--color-gray-200)]">
-              <p className="mb-[10px]">
-                국내 최대 규모 대학생연합 IT벤처창업 동아리 SOPT에서 데모데이
-                &lt;System Update: SUNRISE&gt;를 개최합니다.
-              </p>
-              <p className="mb-[10px]">
-                <br aria-hidden />
-                SOPT는 2008년 창립 이후 IT 창업, 기획, 디자인, 개발에 관심 있는
-                대학생들이 모여 함께 열정을 외치며, 지금까지 약 3,600명 이상의
-                회원이 누적 300개 이상의 프로덕트를 만들어왔습니다.
-              </p>
-              <p className="mb-[10px]">
-                <br aria-hidden />
-                밤새워 써 내려간 수천 줄의 코드와 고민의 흔적들은 단순한 종이
-                뭉치가 아닙니다. 그것은 우리를 더 높은 곳으로 띄우기 위한
-                데이터이자, 가장 뜨거운 열정의 증명입니다.
-              </p>
-              <p className="mb-[10px]">
-                <br aria-hidden />
-                이번 데모데이에서는 ‘치열한 기록들로 띄워낸 가장 완벽한 아침’을
-                주제로, 가장 깊은 몰입 끝에 마주한 37기만의 눈부신 결과물을
-                선보입니다.
-              </p>
-              <p>
-                <span className="head_b_14">
+              <div className="body_r_14 w-full text-[var(--color-gray-200)]">
+                <p className="mb-[10px]">
+                  국내 최대 규모 대학생연합 IT벤처창업 동아리 SOPT에서 데모데이
+                  &lt;System Update: SUNRISE&gt;를 개최합니다.
+                </p>
+                <p className="mb-[10px]">
                   <br aria-hidden />
-                  Now Loading Next DIVE... 99%
-                </span>
-                <span className="head_b_14">
+                  SOPT는 2008년 창립 이후 IT 창업, 기획, 디자인, 개발에 관심
+                  있는 대학생들이 모여 함께 열정을 외치며, 지금까지 약 3,600명
+                  이상의 회원이 누적 300개 이상의 프로덕트를 만들어왔습니다.
+                </p>
+                <p className="mb-[10px]">
                   <br aria-hidden />
-                </span>
-                로딩이 끝나는 순간 떠오를, 우리의 새로운 시스템 업데이트를 지금
-                확인해 주세요.
-              </p>
-            </div>
-          </section>
+                  밤새워 써 내려간 수천 줄의 코드와 고민의 흔적들은 단순한 종이
+                  뭉치가 아닙니다. 그것은 우리를 더 높은 곳으로 띄우기 위한
+                  데이터이자, 가장 뜨거운 열정의 증명입니다.
+                </p>
+                <p className="mb-[10px]">
+                  <br aria-hidden />
+                  이번 데모데이에서는 ‘치열한 기록들로 띄워낸 가장 완벽한
+                  아침’을 주제로, 가장 깊은 몰입 끝에 마주한 37기만의 눈부신
+                  결과물을 선보입니다.
+                </p>
+                <p>
+                  <span className="head_b_14">
+                    <br aria-hidden />
+                    Now Loading Next DIVE... 99%
+                  </span>
+                  <span className="head_b_14">
+                    <br aria-hidden />
+                  </span>
+                  로딩이 끝나는 순간 떠오를, 우리의 새로운 시스템 업데이트를
+                  지금 확인해 주세요.
+                </p>
+              </div>
+            </section>
+          </FadeInView>
 
           <Divider />
 
           <section className="flex w-full flex-col gap-[56px]">
-            <section className="flex w-full flex-col gap-[24px] px-[16px]">
-              <TagMain>행사 개요</TagMain>
-              <div className="flex items-center gap-[16px] px-[4px]">
-                <div className="body_r_14 flex w-[40px] shrink-0 flex-col gap-[6px] text-[var(--color-gray-300)]">
-                  <p>행사명</p>
-                  <p>장소</p>
-                  <p>일시</p>
+            <FadeInView className="w-full" delay={0.1}>
+              <section className="flex w-full flex-col gap-[24px] px-[16px]">
+                <TagMain>행사 개요</TagMain>
+                <div className="flex items-center gap-[16px] px-[4px]">
+                  <div className="body_r_14 flex w-[40px] shrink-0 flex-col gap-[6px] text-[var(--color-gray-300)]">
+                    <p>행사명</p>
+                    <p>장소</p>
+                    <p>일시</p>
+                  </div>
+                  <div className="body_r_14 flex min-w-0 flex-1 flex-col gap-[6px] text-[var(--color-white)]">
+                    <p>SOPT 37기 앱잼 데모데이 : SUNRISE</p>
+                    <p className="text-[var(--color-gray-100)]">마곡 NSP홀</p>
+                    <p>2026.01.24(토) 10:20 ~ 17:00</p>
+                  </div>
                 </div>
-                <div className="body_r_14 flex min-w-0 flex-1 flex-col gap-[6px] text-[var(--color-white)]">
-                  <p>SOPT 37기 앱잼 데모데이 : SUNRISE</p>
-                  <p className="text-[var(--color-gray-100)]">마곡 NSP홀</p>
-                  <p>2026.01.24(토) 10:20 ~ 17:00</p>
+              </section>
+            </FadeInView>
+
+            <FadeInView className="w-full" delay={0.2}>
+              <section className="flex w-full flex-col gap-[24px] px-[16px]">
+                <TagMain>DIVE SOPT APPJAM Demoday</TagMain>
+                <p className="body_r_14 w-full text-[var(--color-gray-300)]">
+                  이번 앱잼 데모데이 &lt;System Update: SUNRISE&gt;에서는 SOPT의
+                  꽃 앱잼(APPJAM) 뿐만 아니라 SOPT를 위한 프로덕트를 만드는
+                  메이커스(Makers)의 결과물까지 함께 만나보실 수 있습니다.
+                </p>
+              </section>
+            </FadeInView>
+
+            <FadeInView className="w-full" delay={0.3}>
+              <section className="flex w-full flex-col gap-[24px] px-[16px]">
+                <TagMain className="text-[var(--color-gray-100)]">
+                  Shout Our Passion Together
+                </TagMain>
+                <div className="body_r_14 w-full text-[var(--color-gray-300)]">
+                  <p className="mb-0">
+                    SOPT는 국내 최대 규모의 대학생 연합 IT 벤처창업 동아리로,
+                    2008년에 창립되어 18년째 대학생 창업 생태계 발전을 위해
+                    노력하고 있습니다.
+                  </p>
+                  <p className="mb-0">&nbsp;</p>
+                  <p className="mb-0">
+                    IT 창업 및 기획, 디자인, 개발에 관심 있는 대학생들이 모여
+                    함께 열정을 외치며 지금까지 3,800명 이상의 회원이 400개가
+                    넘는 프로덕트를 만들었습니다.
+                  </p>
+                  <p className="mb-0">&nbsp;</p>
+                  <p>
+                    SOPT는 Shout Our Passion Together라는 이름 뜻처럼, 앞으로도
+                    많은 사람들의 열정을 외치며 더욱 크게 도전하고자 합니다.
+                  </p>
                 </div>
-              </div>
-            </section>
-
-            <section className="flex w-full flex-col gap-[24px] px-[16px]">
-              <TagMain>DIVE SOPT APPJAM Demoday</TagMain>
-              <p className="body_r_14 w-full text-[var(--color-gray-300)]">
-                이번 앱잼 데모데이 &lt;System Update: SUNRISE&gt;에서는 SOPT의
-                꽃 앱잼(APPJAM) 뿐만 아니라 SOPT를 위한 프로덕트를 만드는
-                메이커스(Makers)의 결과물까지 함께 만나보실 수 있습니다.
-              </p>
-            </section>
-
-            <section className="flex w-full flex-col gap-[24px] px-[16px]">
-              <TagMain className="text-[var(--color-gray-100)]">
-                Shout Our Passion Together
-              </TagMain>
-              <div className="body_r_14 w-full text-[var(--color-gray-300)]">
-                <p className="mb-0">
-                  SOPT는 국내 최대 규모의 대학생 연합 IT 벤처창업 동아리로,
-                  2008년에 창립되어 18년째 대학생 창업 생태계 발전을 위해
-                  노력하고 있습니다.
-                </p>
-                <p className="mb-0">&nbsp;</p>
-                <p className="mb-0">
-                  IT 창업 및 기획, 디자인, 개발에 관심 있는 대학생들이 모여 함께
-                  열정을 외치며 지금까지 3,800명 이상의 회원이 400개가 넘는
-                  프로덕트를 만들었습니다.
-                </p>
-                <p className="mb-0">&nbsp;</p>
-                <p>
-                  SOPT는 Shout Our Passion Together라는 이름 뜻처럼, 앞으로도
-                  많은 사람들의 열정을 외치며 더욱 크게 도전하고자 합니다.
-                </p>
-              </div>
-            </section>
+              </section>
+            </FadeInView>
           </section>
 
           <Divider />
 
-          <section className="flex w-full flex-col gap-[8px] px-[16px] pb-[48px]">
-            <section className="flex flex-col gap-[12px]">
-              <p className="title_m_12 text-[var(--color-gray-200)]">
-                Connect with SOPT
-              </p>
+          <FadeInView className="w-full" delay={0.1}>
+            <section className="flex w-full flex-col gap-[8px] px-[16px] pb-[48px]">
+              <section className="flex flex-col gap-[12px]">
+                <p className="title_m_12 text-[var(--color-gray-200)]">
+                  Connect with SOPT
+                </p>
 
-              <div className="flex flex-col items-start">
-                <div className="flex h-[20px] w-fit items-center gap-[4px] text-[var(--color-gray-400)]">
-                  <YoutubeIcon width={20} height={20} />
-                  <p className="title_m_12 opacity-80">soptmedia</p>
+                <div className="flex flex-col items-start">
+                  <div className="flex h-[20px] w-fit items-center gap-[4px] text-[var(--color-gray-400)]">
+                    <YoutubeIcon width={20} height={20} />
+                    <p className="title_m_12 opacity-80">soptmedia</p>
+                  </div>
+                  <div className="flex h-[20px] w-fit items-center gap-[4px] text-[var(--color-gray-400)]">
+                    <InstagramIcon width={20} height={20} />
+                    <p className="title_m_12 opacity-80">sopt_official</p>
+                  </div>
+                  <div className="flex h-[20px] w-fit items-center gap-[4px] text-[var(--color-gray-400)]">
+                    <LinkIcon width={20} height={20} />
+                    <p className="title_m_12 opacity-80">sopt.org</p>
+                  </div>
                 </div>
-                <div className="flex h-[20px] w-fit items-center gap-[4px] text-[var(--color-gray-400)]">
-                  <InstagramIcon width={20} height={20} />
-                  <p className="title_m_12 opacity-80">sopt_official</p>
-                </div>
-                <div className="flex h-[20px] w-fit items-center gap-[4px] text-[var(--color-gray-400)]">
-                  <LinkIcon width={20} height={20} />
-                  <p className="title_m_12 opacity-80">sopt.org</p>
-                </div>
-              </div>
-            </section>
+              </section>
 
-            <section className="flex w-full flex-col items-end justify-end gap-[12px]">
-              <p className="title_m_12 text-[var(--color-gray-200)]">
-                후원 및 협력
-              </p>
-              <div className="flex w-[176px] flex-wrap content-end items-end justify-end gap-[12px] mix-blend-luminosity">
-                <div className="relative h-[14px] w-[50px]">
-                  <Image
-                    src="/assets/figma/main/sponsor_image_459.webp"
-                    alt=""
-                    fill
-                    className="object-contain"
-                    sizes="50px"
-                  />
+              <section className="flex w-full flex-col items-end justify-end gap-[12px]">
+                <p className="title_m_12 text-[var(--color-gray-200)]">
+                  후원 및 협력
+                </p>
+                <div className="flex w-[176px] flex-wrap content-end items-end justify-end gap-[12px] mix-blend-luminosity">
+                  <div className="relative h-[14px] w-[50px]">
+                    <Image
+                      src="/assets/figma/main/sponsor_image_459.webp"
+                      alt=""
+                      fill
+                      className="object-contain"
+                      sizes="50px"
+                    />
+                  </div>
+                  <div className="relative h-[20px] w-[50px]">
+                    <Image
+                      src="/assets/figma/main/sponsor_kakao.webp"
+                      alt=""
+                      fill
+                      className="object-contain"
+                      sizes="50px"
+                    />
+                  </div>
+                  <div className="relative h-[24px] w-[50px] opacity-70">
+                    <div
+                      className="absolute top-0 left-0"
+                      style={{
+                        width: '51.627px',
+                        height: '14.503px',
+                        marginLeft: '-0.58px',
+                        marginTop: '10.71px',
+                        backgroundColor: 'var(--color-white)',
+                        WebkitMaskImage:
+                          "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
+                        maskImage:
+                          "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
+                        WebkitMaskSize: '50px 24px',
+                        maskSize: '50px 24px',
+                        WebkitMaskPosition: '0.577px -10.708px',
+                        maskPosition: '0.577px -10.708px',
+                        WebkitMaskRepeat: 'no-repeat',
+                        maskRepeat: 'no-repeat',
+                      }}
+                    />
+                    <div
+                      className="absolute top-0 left-0"
+                      style={{
+                        width: '51.627px',
+                        height: '11.588px',
+                        marginLeft: '-0.58px',
+                        marginTop: '-0.88px',
+                        backgroundColor: '#3441ff',
+                        WebkitMaskImage:
+                          "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
+                        maskImage:
+                          "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
+                        WebkitMaskSize: '50px 24px',
+                        maskSize: '50px 24px',
+                        WebkitMaskPosition: '0.577px 0.88px',
+                        maskPosition: '0.577px 0.88px',
+                        WebkitMaskRepeat: 'no-repeat',
+                        maskRepeat: 'no-repeat',
+                      }}
+                    />
+                  </div>
+                  <div className="relative h-[20px] w-[49px] opacity-70">
+                    <div
+                      className="absolute top-0 left-0"
+                      style={{
+                        width: '49px',
+                        height: '20px',
+                        marginLeft: '-0.03px',
+                        marginTop: '-0.21px',
+                        backgroundColor: 'var(--color-white)',
+                        WebkitMaskImage:
+                          "url('/assets/figma/main/sponsor_rectangle_34624741.png')",
+                        maskImage:
+                          "url('/assets/figma/main/sponsor_rectangle_34624741.png')",
+                        WebkitMaskSize: '49px 20px',
+                        maskSize: '49px 20px',
+                        WebkitMaskPosition: '0.031px 0.208px',
+                        maskPosition: '0.031px 0.208px',
+                        WebkitMaskRepeat: 'no-repeat',
+                        maskRepeat: 'no-repeat',
+                      }}
+                    />
+                  </div>
+                  <div className="relative h-[15px] w-[50px]">
+                    <Image
+                      src="/assets/figma/main/sponsor_image_461.webp"
+                      alt=""
+                      fill
+                      className="object-contain"
+                      sizes="50px"
+                    />
+                  </div>
+                  <div className="relative h-[18px] w-[50px]">
+                    <Image
+                      src="/assets/figma/main/sponsor_image_462.webp"
+                      alt=""
+                      fill
+                      className="object-cover"
+                      sizes="50px"
+                    />
+                  </div>
                 </div>
-                <div className="relative h-[20px] w-[50px]">
-                  <Image
-                    src="/assets/figma/main/sponsor_kakao.webp"
-                    alt=""
-                    fill
-                    className="object-contain"
-                    sizes="50px"
-                  />
-                </div>
-                <div className="relative h-[24px] w-[50px] opacity-70">
-                  <div
-                    className="absolute top-0 left-0"
-                    style={{
-                      width: '51.627px',
-                      height: '14.503px',
-                      marginLeft: '-0.58px',
-                      marginTop: '10.71px',
-                      backgroundColor: 'var(--color-white)',
-                      WebkitMaskImage:
-                        "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
-                      maskImage:
-                        "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
-                      WebkitMaskSize: '50px 24px',
-                      maskSize: '50px 24px',
-                      WebkitMaskPosition: '0.577px -10.708px',
-                      maskPosition: '0.577px -10.708px',
-                      WebkitMaskRepeat: 'no-repeat',
-                      maskRepeat: 'no-repeat',
-                    }}
-                  />
-                  <div
-                    className="absolute top-0 left-0"
-                    style={{
-                      width: '51.627px',
-                      height: '11.588px',
-                      marginLeft: '-0.58px',
-                      marginTop: '-0.88px',
-                      backgroundColor: '#3441ff',
-                      WebkitMaskImage:
-                        "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
-                      maskImage:
-                        "url('/assets/figma/main/sponsor_rectangle_34624742.png')",
-                      WebkitMaskSize: '50px 24px',
-                      maskSize: '50px 24px',
-                      WebkitMaskPosition: '0.577px 0.88px',
-                      maskPosition: '0.577px 0.88px',
-                      WebkitMaskRepeat: 'no-repeat',
-                      maskRepeat: 'no-repeat',
-                    }}
-                  />
-                </div>
-                <div className="relative h-[20px] w-[49px] opacity-70">
-                  <div
-                    className="absolute top-0 left-0"
-                    style={{
-                      width: '49px',
-                      height: '20px',
-                      marginLeft: '-0.03px',
-                      marginTop: '-0.21px',
-                      backgroundColor: 'var(--color-white)',
-                      WebkitMaskImage:
-                        "url('/assets/figma/main/sponsor_rectangle_34624741.png')",
-                      maskImage:
-                        "url('/assets/figma/main/sponsor_rectangle_34624741.png')",
-                      WebkitMaskSize: '49px 20px',
-                      maskSize: '49px 20px',
-                      WebkitMaskPosition: '0.031px 0.208px',
-                      maskPosition: '0.031px 0.208px',
-                      WebkitMaskRepeat: 'no-repeat',
-                      maskRepeat: 'no-repeat',
-                    }}
-                  />
-                </div>
-                <div className="relative h-[15px] w-[50px]">
-                  <Image
-                    src="/assets/figma/main/sponsor_image_461.webp"
-                    alt=""
-                    fill
-                    className="object-contain"
-                    sizes="50px"
-                  />
-                </div>
-                <div className="relative h-[18px] w-[50px]">
-                  <Image
-                    src="/assets/figma/main/sponsor_image_462.webp"
-                    alt=""
-                    fill
-                    className="object-cover"
-                    sizes="50px"
-                  />
-                </div>
-              </div>
+              </section>
             </section>
-          </section>
+          </FadeInView>
         </section>
       </section>
     </main>

--- a/apps/web/src/app/(tabs)/products/ProductsPageClient.tsx
+++ b/apps/web/src/app/(tabs)/products/ProductsPageClient.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import FadeInView from '@/components/common/FadeInView';
 import ProductCard from '@/components/feature/product-card/ProductCard';
 import FilterChip from '@/components/ui/FilterChip/FilterChip';
 import Tabs, { type TabsValue } from '@/components/ui/Tabs/Tabs';
@@ -71,23 +72,29 @@ export default function ProductsPageClient() {
           총 {filteredProducts.length}개의 서비스
         </p>
         <div className="grid w-full grid-cols-2 gap-x-[17px] gap-y-[16px]">
-          {filteredProducts.map((product) => (
-            <ProductCard
+          {filteredProducts.map((product, index) => (
+            <FadeInView
               key={product.teamKey}
-              thumbnailSrc={product.thumbnailSrc}
-              thumbnailAlt={product.title}
-              title={product.title}
-              category={product.category}
-              description={product.description}
-              onClick={() => {
-                trackEvent('product_select', {
-                  product_id: product.teamKey,
-                  track: product.track,
-                  platform: product.platform,
-                });
-                router.push(`/products/${product.teamKey}`);
-              }}
-            />
+              distance={20}
+              duration={0.5}
+              delay={Math.min(index * 0.03, 0.3)}
+            >
+              <ProductCard
+                thumbnailSrc={product.thumbnailSrc}
+                thumbnailAlt={product.title}
+                title={product.title}
+                category={product.category}
+                description={product.description}
+                onClick={() => {
+                  trackEvent('product_select', {
+                    product_id: product.teamKey,
+                    track: product.track,
+                    platform: product.platform,
+                  });
+                  router.push(`/products/${product.teamKey}`);
+                }}
+              />
+            </FadeInView>
           ))}
         </div>
       </section>

--- a/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
+++ b/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
@@ -5,6 +5,7 @@ import { useEffect, type ReactElement } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
+import FadeInView from '@/components/common/FadeInView';
 import {
   AndroidIcon,
   DesignIcon,
@@ -228,14 +229,16 @@ export default function ProductDetailPageClient({
 
           {/* detail image */}
           {product.detailImageSrc ? (
-            <div aria-label="상세 이미지 영역">
-              <img
-                src={product.detailImageSrc}
-                alt={`${product.title} 상세 이미지`}
-                className="h-auto w-full"
-                loading="lazy"
-              />
-            </div>
+            <FadeInView>
+              <div aria-label="상세 이미지 영역">
+                <img
+                  src={product.detailImageSrc}
+                  alt={`${product.title} 상세 이미지`}
+                  className="h-auto w-full"
+                  loading="lazy"
+                />
+              </div>
+            </FadeInView>
           ) : null}
         </main>
 

--- a/apps/web/src/components/common/FadeInView.tsx
+++ b/apps/web/src/components/common/FadeInView.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useRef } from 'react';
+
+import { motion, useInView } from 'motion/react';
+
+type FadeInViewProps = {
+  children: ReactNode;
+  className?: string;
+  distance?: number;
+  duration?: number;
+  delay?: number;
+  amount?: number;
+};
+
+export default function FadeInView({
+  children,
+  className,
+  distance = 30,
+  duration = 0.6,
+  delay = 0,
+  amount = 0.2,
+}: FadeInViewProps) {
+  // intersection ref
+  const ref = useRef<HTMLDivElement | null>(null);
+  const isInView = useInView(ref, { once: true, amount });
+
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      initial={{ opacity: 0, y: distance }}
+      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: distance }}
+      transition={{ duration, delay, ease: 'easeOut' }}
+    >
+      {children}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## 📌 Summary

- close #159
- 36기 데모데이 웹사이트의 `FadeInView` 패턴을 참고하여 37기 웹에 섹션 등장 애니메이션을 적용합니다.
- 홈(/) 주요 정보 섹션과 프로덕트(/products) 카드/상세(/products/[teamKey])의 이미지 영역이 스크롤 진입 시 부드럽게 나타나도록 개선합니다.

## 📄 Tasks

- [x] 공통 컴포넌트 `FadeInView` 추가 (motion/react)
- [x] 홈(/) 섹션 단위 `FadeInView` 적용
- [x] 프로덕트(/products) 카드 리스트 `FadeInView` 적용
- [x] 프로덕트 상세(/products/[teamKey]) 상세 이미지 영역 `FadeInView` 적용
- [x] `pnpm lint` / `pnpm --filter sopt-37th-demoday build` 확인

## 🔍 To Reviewer

- 모션 강도(거리/지속시간)가 과하지 않은지 확인 부탁드립니다.
- 섹션별 delay 값(0.1/0.2/0.3)이 자연스러운지 의견 부탁드립니다.

## 📸 Screenshot

-
