### PR TITLE
[fix] 로그인/리플렛 상단 로고 긴 이미지 노출

### DIFF
--- a/apps/web/src/components/layout/nav-top/NavTop.tsx
+++ b/apps/web/src/components/layout/nav-top/NavTop.tsx
@@ -3,6 +3,8 @@ import { TouchArea } from '@/components/ui';
 
 import LeafletStampQrMenu from './components/LeafletStampQrMenu.client';
 
+const TOP_LOGO_SRC = '/assets/figma/main/img_logo.png';
+
 export type NavTopProps =
   | {
       variant?: 'main';
@@ -56,15 +58,19 @@ export default function NavTop(props: NavTopProps) {
     >
       <img
         alt="SYSTEM UPDATE : SUNRISE"
-        src={
-          showQr
-            ? '/assets/leaflet/icons/sunrise-text.svg'
-            : '/assets/leaflet/icons/sunrise-text-mask.svg'
-        }
+        src={TOP_LOGO_SRC}
         className={
           showQr
-            ? 'absolute top-1/2 left-[24px] h-[14.0996px] -translate-y-1/2'
-            : 'h-[38.5px] w-[286px]'
+            ? 'absolute top-1/2 left-[24px] h-[14.0996px] w-auto shrink-0 -translate-y-1/2'
+            : 'w-[286px] shrink-0'
+        }
+        style={
+          showQr
+            ? {
+                filter:
+                  'drop-shadow(1px 0 0 #000) drop-shadow(-1px 0 0 #000) drop-shadow(0 1px 0 #000) drop-shadow(0 -1px 0 #000)',
+              }
+            : undefined
         }
       />
 


### PR DESCRIPTION
## 📌 Summary

- close #160
- 로그인/리플렛 상단에서 긴 로고 이미지가 전체 노출되도록 수정합니다.
- 리플렛(우측 QR 메뉴 노출)에서는 outline 느낌이 유지되도록 스타일을 조정합니다.

## 📄 Tasks

- [x] 상단 네비게이션(메인) 로고를 긴 이미지로 통일합니다.
- [x] 리플렛 상단 로고의 outline 느낌이 유지되도록 조정합니다.

## 🔍 To Reviewer

- 로그인(`/login`)과 리플렛(`/leaflet`)에서 상단 로고 노출을 확인 부탁드립니다.

## 📸 Screenshot

-
