### PR TITLE
[fix] 후원사 로고 깜빡임 방지

### DIFF
--- a/apps/web/src/app/(tabs)/page.tsx
+++ b/apps/web/src/app/(tabs)/page.tsx
@@ -154,7 +154,7 @@ export default function Home() {
 
           <Divider />
 
-          <FadeInView className="w-full" delay={0.1}>
+          <FadeInView className="w-full" delay={0.1} distance={0}>
             <section className="flex w-full flex-col gap-[8px] px-[16px] pb-[48px]">
               <section className="flex flex-col gap-[12px]">
                 <p className="title_m_12 text-[var(--color-gray-200)]">

--- a/apps/web/src/components/common/FadeInView.tsx
+++ b/apps/web/src/components/common/FadeInView.tsx
@@ -26,12 +26,16 @@ export default function FadeInView({
   const ref = useRef<HTMLDivElement | null>(null);
   const isInView = useInView(ref, { once: true, amount });
 
+  const hiddenState =
+    distance === 0 ? { opacity: 0 } : { opacity: 0, y: distance };
+  const shownState = distance === 0 ? { opacity: 1 } : { opacity: 1, y: 0 };
+
   return (
     <motion.div
       ref={ref}
       className={className}
-      initial={{ opacity: 0, y: distance }}
-      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: distance }}
+      initial={hiddenState}
+      animate={isInView ? shownState : hiddenState}
       transition={{ duration, delay, ease: 'easeOut' }}
     >
       {children}


### PR DESCRIPTION
## 📌 Summary

- 홈 하단 후원사 로고 영역에서 `mix-blend-luminosity`가 `transform` 애니메이션과 만나며 발생하던 컬러→흑백 깜빡임을 방지합니다.
- 해당 섹션은 opacity 페이드인만 적용되도록 조정하고, `FadeInView`는 `distance=0`일 때 `transform`을 생성하지 않도록 보완합니다.

## 📄 Tasks

- [x] `FadeInView`에서 `distance=0` 케이스 처리(translateY 제거)
- [x] 홈 하단 후원/협력 섹션 `distance={0}` 적용

## 🔍 To Reviewer

- `mix-blend-luminosity` 유지 + flicker 제거 목적이라, 모션은 opacity만 남겨둔 점 확인 부탁드립니다.

## 📸 Screenshot

-
