### PR TITLE
[fix] 프로덕트 태그 수직 정렬

### DIFF
--- a/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
+++ b/apps/web/src/app/products/[teamKey]/ProductDetailPageClient.tsx
@@ -119,11 +119,11 @@ export default function ProductDetailPageClient({
 
             <div className="flex w-full flex-col items-start gap-[12px] rounded-[2px] bg-[var(--color-gray-900)] p-[12px]">
               <div className="flex w-full flex-col items-start gap-[16px]">
-                <div className="flex items-start gap-[8px]">
+                <div className="flex items-center gap-[8px]">
                   <p className="head_b_20 text-[var(--color-white)]">
                     {product.title}
                   </p>
-                  <div className="flex items-start gap-[6px]">
+                  <div className="flex items-center gap-[6px]">
                     <TagProduct>{product.category}</TagProduct>
                     <TagProduct>{platformLabel}</TagProduct>
                   </div>

--- a/apps/web/src/components/feature/product-card/ProductCard.tsx
+++ b/apps/web/src/components/feature/product-card/ProductCard.tsx
@@ -52,7 +52,7 @@ export default function ProductCard({
 
       {/* content */}
       <div className="flex w-full shrink-0 flex-col items-start gap-[8px] px-[12px]">
-        <div className="flex w-full shrink-0 items-start gap-[8px]">
+        <div className="flex w-full shrink-0 items-center gap-[8px]">
           <p className="head_b_16 text-[var(--color-gray-100)]">{title}</p>
           <span className="body_r_12 shrink-0 rounded-[2px] bg-[var(--color-black)] px-[8px] py-[2px] text-[var(--color-gray-300)]">
             {category}


### PR DESCRIPTION
## 📌 Summary

- close # (이슈 없이 진행)
- 프로덕트 목록/상세에서 제목 옆 태그가 상단으로 치우치는 정렬 문제를 수정합니다.

## 📄 Tasks

- `ProductCard`의 제목/태그 row를 `items-center`로 정렬합니다.
- `ProductDetailPageClient`의 제목/태그 row를 `items-center`로 정렬합니다.

## 🔍 To Reviewer

- 목록/상세에서 제목과 태그가 수직 중앙 정렬되는지 확인 부탁드립니다.

## 📸 Screenshot

-
