### PR TITLE
[fix] iOS Chrome 스크롤 시 하단 탭바 정렬 수정

### DIFF
--- a/apps/web/src/app/(tabs)/layout.tsx
+++ b/apps/web/src/app/(tabs)/layout.tsx
@@ -13,7 +13,7 @@ export default function TabsLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="mx-auto w-full max-w-[var(--app-max-width)]">
-      <div className="flex min-h-[100dvh] flex-col pb-[var(--nav-bottom-height)]">
+      <div className="flex min-h-[100dvh] flex-col pb-[calc(var(--nav-bottom-height)+var(--safe-area-bottom))]">
         {children}
         {hideFooter ? null : (
           <div className="mt-auto">
@@ -21,7 +21,7 @@ export default function TabsLayout({ children }: { children: ReactNode }) {
           </div>
         )}
       </div>
-      <div className="fixed bottom-0 left-1/2 z-50 h-[var(--nav-bottom-height)] w-full max-w-[var(--app-max-width)] -translate-x-1/2 bg-[var(--color-black-overlay)] pb-[var(--safe-area-bottom)] backdrop-blur-md">
+      <div className="fixed bottom-0 left-1/2 z-50 h-[calc(var(--nav-bottom-height)+var(--safe-area-bottom))] w-full max-w-[var(--app-max-width)] -translate-x-1/2 bg-[var(--color-black-overlay)] pb-[var(--safe-area-bottom)] backdrop-blur-md">
         <NavBottom />
       </div>
     </div>

--- a/apps/web/src/components/layout/nav-bottom/NavBottom.tsx
+++ b/apps/web/src/components/layout/nav-bottom/NavBottom.tsx
@@ -102,7 +102,7 @@ export default function NavBottom({ active, onNavigate }: NavBottomProps) {
 
   return (
     <nav
-      className="shadow_top grid h-[calc(var(--nav-bottom-height)-var(--safe-area-bottom))] grid-cols-4 px-[16px]"
+      className="shadow_top grid h-[var(--nav-bottom-height)] grid-cols-4 px-[16px]"
       aria-label="하단 탭 내비게이션"
     >
       <NavBottomButton


### PR DESCRIPTION
## 📌 Summary

- close #156
- iOS Chrome에서 스크롤 시 하단 탭바(NavBottom) 아이콘/라벨이 위로 쏠리는 현상을 완화합니다.

## 📄 Tasks

- 하단 탭바 영역에서 safe-area 처리로 인해 내부 높이가 줄어들지 않도록 레이아웃 계산을 조정합니다.

## 🔍 To Reviewer

- iOS Chrome에서 스크롤 전/후 하단 탭바 아이콘/라벨 정렬이 동일하게 유지되는지 확인 부탁드립니다.

## 📸 Screenshot

-
